### PR TITLE
Fix character counting

### DIFF
--- a/processors/strings.go
+++ b/processors/strings.go
@@ -60,7 +60,7 @@ func StringToSlug(input string) string {
 
 // CountNumberCharacters count number of Characters including spaces.
 func CountNumberCharacters(input string) string {
-	return fmt.Sprintf("%d", len(input))
+	return fmt.Sprintf("%d", len([]rune(input)))
 }
 
 // CountWords count number of words in string.

--- a/processors/strings_test.go
+++ b/processors/strings_test.go
@@ -18,11 +18,16 @@ func TestCountNumberCharacters(t *testing.T) {
 		}, {
 			name: "Emoji",
 			args: args{input: "😃😇🙃🙂😉😌😙😗🇮🇳"},
-			want: "40",
+			want: "10",
 		}, {
 			name: "Multi line string",
 			args: args{input: "123345\nabcd\n456\n123\nabc\n567\n7890"},
 			want: "32",
+		},
+		{
+			name: "Double-byte characters",
+			args: args{input: "你好"},
+			want: "2",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This update fixes character counting, which was previously returning the number of bytes rather than the number of runes.

For reference, note that with Latin one character is generally one byte, however other unicode characters (such as East-Asian characters and emojis) can have multiple bytes per character.

|String|Chars|Bytes|
|-|-|-|
|`hi`|2|2|
|`你好`|2|6|

Example: https://play.golang.org/p/hWrTqV9HxWb