### PR TITLE
Read files

### DIFF
--- a/cmd/processor_base32-decode.go
+++ b/cmd/processor_base32-decode.go
@@ -19,10 +19,12 @@ var base32DecodeCmd = &cobra.Command{
 	Use:     "base32-decode",
 	Short:   "Decode your base32 text",
 	Aliases: []string{"b32-dec", "b32-decode"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var base32DecodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Base32Decode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_base32-encode.go
+++ b/cmd/processor_base32-encode.go
@@ -19,10 +19,12 @@ var base32EncodeCmd = &cobra.Command{
 	Use:     "base32-encode",
 	Short:   "Encode your text to Base32",
 	Aliases: []string{"b32-enc", "b32-encode"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var base32EncodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Base32Encoding{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_base64-decode.go
+++ b/cmd/processor_base64-decode.go
@@ -19,10 +19,12 @@ var base64DecodeCmd = &cobra.Command{
 	Use:     "base64-decode",
 	Short:   "Decode your base64 text",
 	Aliases: []string{"b64-dec", "b64-decode"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var base64DecodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Base64Decode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_base64-encode.go
+++ b/cmd/processor_base64-encode.go
@@ -19,10 +19,12 @@ var base64EncodeCmd = &cobra.Command{
 	Use:     "base64-encode",
 	Short:   "Encode your text to Base64",
 	Aliases: []string{"b64-enc", "b64-encode"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var base64EncodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Base64Encode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_camel.go
+++ b/cmd/processor_camel.go
@@ -19,10 +19,12 @@ var camelCmd = &cobra.Command{
 	Use:     "camel",
 	Short:   "Transform your text to CamelCase",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var camelCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Camel{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_count-chars.go
+++ b/cmd/processor_count-chars.go
@@ -19,10 +19,12 @@ var countCharsCmd = &cobra.Command{
 	Use:     "count-chars",
 	Short:   "Find the length of your text (including spaces)",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var countCharsCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.CountCharacters{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_count-lines.go
+++ b/cmd/processor_count-lines.go
@@ -19,10 +19,12 @@ var countLinesCmd = &cobra.Command{
 	Use:     "count-lines",
 	Short:   "Count the number of lines in your text",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var countLinesCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.CountLines{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_count-words.go
+++ b/cmd/processor_count-words.go
@@ -19,10 +19,12 @@ var countWordsCmd = &cobra.Command{
 	Use:     "count-words",
 	Short:   "Count the number of words in your text",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var countWordsCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.CountWords{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_hex-rgb.go
+++ b/cmd/processor_hex-rgb.go
@@ -19,10 +19,12 @@ var hexRgbCmd = &cobra.Command{
 	Use:     "hex-rgb",
 	Short:   "Convert a #hex-color code to RGB",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var hexRgbCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.HexToRGB{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_html-decode.go
+++ b/cmd/processor_html-decode.go
@@ -19,10 +19,12 @@ var htmlDecodeCmd = &cobra.Command{
 	Use:     "html-decode",
 	Short:   "Unescape your HTML",
 	Aliases: []string{"html-dec", "html-unescape"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var htmlDecodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.HTMLDecode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_html-encode.go
+++ b/cmd/processor_html-encode.go
@@ -19,10 +19,12 @@ var htmlEncodeCmd = &cobra.Command{
 	Use:     "html-encode",
 	Short:   "Escape your HTML",
 	Aliases: []string{"html-enc", "html-escape"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var htmlEncodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.HTMLEncode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_json.go
+++ b/cmd/processor_json.go
@@ -22,10 +22,12 @@ var jsonCmd = &cobra.Command{
 	Use:     "json",
 	Short:   "Format your text as JSON",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -33,11 +35,22 @@ var jsonCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.FormatJSON{}
-		flags := make([]processors.Flag, 0)
 		flags = append(flags, processors.Flag{Short: "i", Value: json_flag_i})
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_kebab.go
+++ b/cmd/processor_kebab.go
@@ -19,10 +19,12 @@ var kebabCmd = &cobra.Command{
 	Use:     "kebab",
 	Short:   "Transform your text to kebab-case",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var kebabCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Kebab{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_lower.go
+++ b/cmd/processor_lower.go
@@ -19,10 +19,12 @@ var lowerCmd = &cobra.Command{
 	Use:     "lower",
 	Short:   "Transform your text to lower case",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var lowerCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Lower{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_md5-sum.go
+++ b/cmd/processor_md5-sum.go
@@ -19,10 +19,12 @@ var md5SumCmd = &cobra.Command{
 	Use:     "md5-sum",
 	Short:   "Get the MD5 checksum of your text",
 	Aliases: []string{"md5"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var md5SumCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.MD5Encode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_reverse.go
+++ b/cmd/processor_reverse.go
@@ -19,10 +19,12 @@ var reverseCmd = &cobra.Command{
 	Use:     "reverse",
 	Short:   "Reverse Text ( txeT esreveR )",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var reverseCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Reverse{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_rot13-encode.go
+++ b/cmd/processor_rot13-encode.go
@@ -19,10 +19,12 @@ var rot13EncodeCmd = &cobra.Command{
 	Use:     "rot13-encode",
 	Short:   "Encode your text to ROT13",
 	Aliases: []string{"rot13", "rot13-enc"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var rot13EncodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.ROT13Encode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_sha256-sum.go
+++ b/cmd/processor_sha256-sum.go
@@ -19,10 +19,12 @@ var sha256SumCmd = &cobra.Command{
 	Use:     "sha256-sum",
 	Short:   "Get the SHA256 checksum of your text",
 	Aliases: []string{"sha256"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var sha256SumCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.SHA256Encode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_sha512-sum.go
+++ b/cmd/processor_sha512-sum.go
@@ -19,10 +19,12 @@ var sha512SumCmd = &cobra.Command{
 	Use:     "sha512-sum",
 	Short:   "Get the SHA512 checksum of your text",
 	Aliases: []string{"sha512"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var sha512SumCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.SHA512Encode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_slug.go
+++ b/cmd/processor_slug.go
@@ -19,10 +19,12 @@ var slugCmd = &cobra.Command{
 	Use:     "slug",
 	Short:   "Transform your text to slug-case",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var slugCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Slug{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_snake.go
+++ b/cmd/processor_snake.go
@@ -19,10 +19,12 @@ var snakeCmd = &cobra.Command{
 	Use:     "snake",
 	Short:   "Transform your text to snake_case",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var snakeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Snake{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_title.go
+++ b/cmd/processor_title.go
@@ -19,10 +19,12 @@ var titleCmd = &cobra.Command{
 	Use:     "title",
 	Short:   "Transform your text to Title Case",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var titleCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Title{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_upper.go
+++ b/cmd/processor_upper.go
@@ -19,10 +19,12 @@ var upperCmd = &cobra.Command{
 	Use:     "upper",
 	Short:   "Transform your text to UPPER CASE",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var upperCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Upper{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_url-decode.go
+++ b/cmd/processor_url-decode.go
@@ -19,10 +19,12 @@ var urlDecodeCmd = &cobra.Command{
 	Use:     "url-decode",
 	Short:   "Decode URL entities",
 	Aliases: []string{"url-dec"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var urlDecodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.URLDecode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_url-encode.go
+++ b/cmd/processor_url-encode.go
@@ -19,10 +19,12 @@ var urlEncodeCmd = &cobra.Command{
 	Use:     "url-encode",
 	Short:   "Encode URL entities",
 	Aliases: []string{"url-enc"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -30,11 +32,22 @@ var urlEncodeCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.URLEncode{}
-		flags := make([]processors.Flag, 0)
 
 		out, err = p.Transform(in, flags...)
 		if err != nil {

--- a/cmd/processor_yaml-json.go
+++ b/cmd/processor_yaml-json.go
@@ -22,10 +22,12 @@ var yamlJsonCmd = &cobra.Command{
 	Use:     "yaml-json",
 	Short:   "Convert YAML to JSON text",
 	Aliases: []string{"yml-json"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -33,11 +35,22 @@ var yamlJsonCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.YAMLToJSON{}
-		flags := make([]processors.Flag, 0)
 		flags = append(flags, processors.Flag{Short: "i", Value: yamlJson_flag_i})
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_zeropad.go
+++ b/cmd/processor_zeropad.go
@@ -26,10 +26,12 @@ var zeropadCmd = &cobra.Command{
 	Use:     "zeropad",
 	Short:   "Pad a number with zeros",
 	Aliases: []string{},
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		in, out := "", ""
 
+		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
 			all, err := ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
@@ -37,11 +39,22 @@ var zeropadCmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := processors.Zeropad{}
-		flags := make([]processors.Flag, 0)
 		flags = append(flags, processors.Flag{Short: "n", Value: zeropad_flag_n})
 		flags = append(flags, processors.Flag{Short: "p", Value: zeropad_flag_p})
 

--- a/processors/crypto.go
+++ b/processors/crypto.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
+	"github.com/abhimanyu003/sttr/utils"
 )
 
 // MD5Encode encode string to md5.
@@ -20,8 +21,11 @@ func (p MD5Encode) Alias() []string {
 	return []string{"md5"}
 }
 
-func (p MD5Encode) Transform(data string, _ ...Flag) (string, error) {
+func (p MD5Encode) Transform(data string, f ...Flag) (string, error) {
 	hasher := md5.New()
+	if !fromFile(f) {
+		data = utils.TrimTrailingLinebreaks(data)
+	}
 	hasher.Write([]byte(data))
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil
@@ -54,8 +58,11 @@ func (p SHA1Encode) Alias() []string {
 	return []string{"sha1"}
 }
 
-func (p SHA1Encode) Transform(data string, _ ...Flag) (string, error) {
+func (p SHA1Encode) Transform(data string, f ...Flag) (string, error) {
 	h := sha1.New()
+	if !fromFile(f) {
+		data = utils.TrimTrailingLinebreaks(data)
+	}
 	h.Write([]byte(data))
 	bs := h.Sum(nil)
 
@@ -89,8 +96,11 @@ func (p SHA256Encode) Alias() []string {
 	return []string{"sha256"}
 }
 
-func (p SHA256Encode) Transform(data string, _ ...Flag) (string, error) {
+func (p SHA256Encode) Transform(data string, f ...Flag) (string, error) {
 	h := sha256.New()
+	if !fromFile(f) {
+		data = utils.TrimTrailingLinebreaks(data)
+	}
 	h.Write([]byte(data))
 	bs := h.Sum(nil)
 
@@ -124,8 +134,11 @@ func (p SHA512Encode) Alias() []string {
 	return []string{"sha512"}
 }
 
-func (p SHA512Encode) Transform(data string, _ ...Flag) (string, error) {
+func (p SHA512Encode) Transform(data string, f ...Flag) (string, error) {
 	h := sha512.New()
+	if !fromFile(f) {
+		data = utils.TrimTrailingLinebreaks(data)
+	}
 	h.Write([]byte(data))
 	bs := h.Sum(nil)
 

--- a/processors/crypto_test.go
+++ b/processors/crypto_test.go
@@ -65,6 +65,14 @@ func TestMD5Encode_Transform(t *testing.T) {
 			name: "Multi line string",
 			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
 			want: "4da14107f15ce261f2641ab7b8769466",
+		}, {
+			name: "Trimmed linebreak",
+			args: args{data: "Hello World\n"},
+			want: "b10a8db164e0754105b7a99be72e3fe5",
+		}, {
+			name: "With linebreak (from file)",
+			args: args{data: "Hello World\n", in1: []Flag{ {Short: FlagFile, Value: true} }},
+			want: "e59ff97941044f85df5297e1c302d260",
 		},
 	}
 	for _, tt := range tests {
@@ -142,6 +150,14 @@ func TestSHA1Encode_Transform(t *testing.T) {
 			name: "Multi line string",
 			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
 			want: "6dfc74a3e7472a8ca5794962b62b144a82808e2c",
+		}, {
+			name: "Trimmed linebreak",
+			args: args{data: "Hello World\n"},
+			want: "0a4d55a8d778e5022fab701977c5d840bbc486d0",
+		}, {
+			name: "With linebreak (from file)",
+			args: args{data: "Hello World\n", in1: []Flag{ {Short: FlagFile, Value: true} }},
+			want: "648a6a6ffffdaa0badb23b8baf90b6168dd16b3a",
 		},
 	}
 	for _, tt := range tests {
@@ -219,6 +235,14 @@ func TestSHA256Encode_Transform(t *testing.T) {
 			name: "Multi line string",
 			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
 			want: "a5deaf4214a6cf73c20bfb6df0a0ec1d0ade6b3fe7d1845592e49d06082fa039",
+		}, {
+			name: "Trimmed linebreak",
+			args: args{data: "Hello World\n"},
+			want: "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e",
+		}, {
+			name: "With linebreak (from file)",
+			args: args{data: "Hello World\n", in1: []Flag{ {Short: FlagFile, Value: true} }},
+			want: "d2a84f4b8b650937ec8f73cd8be2c74add5a911ba64df27458ed8229da804a26",
 		},
 	}
 	for _, tt := range tests {
@@ -296,6 +320,14 @@ func TestSHA512Encode_Transform(t *testing.T) {
 			name: "Multi line string",
 			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
 			want: "aa53744b761ea00e61737ff65bee640519c21ce1850898a9dfd285057bba9a0cf2a9ba512dcdc1f5c8f6df0666336249495153b3875fa74f32b5e612f858f553",
+		}, {
+			name: "Trimmed linebreak",
+			args: args{data: "Hello World\n"},
+			want: "2c74fd17edafd80e8447b0d46741ee243b7eb74dd2149a0ab1b9246fb30382f27e853d8585719e0e67cbda0daa8f51671064615d645ae27acb15bfb1447f459b",
+		}, {
+			name: "With linebreak (from file)",
+			args: args{data: "Hello World\n", in1: []Flag{ {Short: FlagFile, Value: true} }},
+			want: "e1c112ff908febc3b98b1693a6cd3564eaf8e5e6ca629d084d9f0eba99247cacdd72e369ff8941397c2807409ff66be64be908da17ad7b8a49a2a26c0e8086aa",
 		},
 	}
 	for _, tt := range tests {

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -57,6 +57,7 @@ type Processor interface {
 }
 
 type FlagType string
+const FlagFile = "file"
 
 func (f FlagType) String() string {
 	return string(f)
@@ -87,6 +88,18 @@ type Flag struct {
 
 	// Value - optional default value of the flag
 	Value interface{}
+}
+
+func fromFile(flags []Flag) bool {
+	for _, flag := range flags {
+		if flag.Short == FlagFile {
+			if b, ok := flag.Value.(bool); ok {
+				return b
+			}
+			return false
+		}
+	}
+	return false
 }
 
 // Zeropad is an Example processor to show how to add text processors,

--- a/utils/text.go
+++ b/utils/text.go
@@ -32,6 +32,18 @@ func ReadMultilineInput() string {
 	return strings.Join(str[:len(str)-1], "\n")
 }
 
+// TrimTrailingLinebreaks removes trailing linebreaks ('r', '\n', '\r\n\') from
+// the input
+func TrimTrailingLinebreaks(input string) string {
+	buf := []byte(input)
+	for i := len(buf) - 1; i >= 0; i-- {
+		if buf[i] != '\n' && buf[i] != '\r' {
+			return string(buf[:i+1])
+		}
+	}
+	return ""
+}
+
 func ToKebabCase(input string) string {
 	input = regexp.MustCompile(`\s+`).ReplaceAllString(input, " ")
 	return strcase.ToKebab(input)

--- a/utils/text_test.go
+++ b/utils/text_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestTrimTrailingLinebreaks(t *testing.T) {
+	inputs := []string{
+		"a", "aa", "Hello World", "a ", "Hello World ",
+		" Hello World", " a ", "", " ", "  ", "Hello\nWorld", "Hello\rWorld", "Hello\r\nWord",
+	}
+	type args struct {
+		input     []string
+		linebreak string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "no linebreak",
+			args: args{input: inputs, linebreak: ""},
+		},
+		{
+			name: "lf",
+			args: args{input: inputs, linebreak: "\n"},
+		},
+		{
+			name: "cr",
+			args: args{input: inputs, linebreak: "\r"},
+		},
+		{
+			name: "crlf",
+			args: args{input: inputs, linebreak: "\r\n"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, in := range tt.args.input {
+				if got := TrimTrailingLinebreaks(in + tt.args.linebreak); got != in {
+					t.Errorf("TrimTrailingLinebreaks() = %v, want %v", []byte(got), []byte(in))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds support for input files. The argument will be checked if it is a file and in that case, it will be read and used as input.

In addition, a default flag is set for the processors so that they can react differently to the input.

I noticed that the hash functions give different outputs when you pipe the input.
```shell
> echo "Hello World" | sttr md5
e59ff97941044f85df5297e1c302d260

> sttr "Hello World"
b10a8db164e0754105b7a99be72e3fe5
```
In the first case, a linefeed is passed with the echo command. I have implemented this so that if the input does not come from a file, the trailing line breaks are removed from the input.  I think for simple, single-line inputs, you usually don't want the newline passed into the hash function.
