### PR TITLE
Read files

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -145,7 +145,19 @@ var {{ .Camel }}Cmd = &cobra.Command{
 			}
 			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = string(d)
+				flags = append(flags, processors.Flag{
+					Name:  processors.FlagFile,
+					Value: true,
+				})
+			} else {
+				in = args[0]
+			}
 		}
 
 		p := {{ .SName }}{}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -135,31 +135,27 @@ var {{ .Camel }}Cmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
 			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
 				d, err := ioutil.ReadFile(args[0])
 				if err != nil {
 					return err
 				}
-				in = string(d)
-				flags = append(flags, processors.Flag{
-					Name:  processors.FlagFile,
-					Value: true,
-				})
+				in = d
 			} else {
-				in = args[0]
+				in = []byte(args[0])
 			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := {{ .SName }}{}
 		{{- range .Flags }}
 		flags = append(flags, processors.Flag{Short: "{{.Short}}", Value: {{ $camel }}_flag_{{ .Short }}})

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -41,7 +41,7 @@ func main() {
 		d := data{
 			Name:  p.Name(),
 			Alias: p.Alias(),
-			Camel: utils.ToLowerCamelCase(p.Name()),
+			Camel: utils.ToLowerCamelCase([]byte(p.Name())),
 			SName: fmt.Sprintf("%T", p),
 			Desc:  i.Description(),
 			Flags: p.Flags(),

--- a/cmd/processor_base32-decode.go
+++ b/cmd/processor_base32-decode.go
@@ -22,19 +22,27 @@ var base32DecodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Base32Decode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_base32-encode.go
+++ b/cmd/processor_base32-encode.go
@@ -22,19 +22,27 @@ var base32EncodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Base32Encoding{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_base64-decode.go
+++ b/cmd/processor_base64-decode.go
@@ -22,19 +22,27 @@ var base64DecodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Base64Decode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_base64-encode.go
+++ b/cmd/processor_base64-encode.go
@@ -22,19 +22,27 @@ var base64EncodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Base64Encode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_bcrypt.go
+++ b/cmd/processor_bcrypt.go
@@ -25,19 +25,27 @@ var bcryptCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Bcrypt{}
 		flags = append(flags, processors.Flag{Short: "r", Value: bcrypt_flag_r})
 

--- a/cmd/processor_camel.go
+++ b/cmd/processor_camel.go
@@ -22,19 +22,27 @@ var camelCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Camel{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_count-chars.go
+++ b/cmd/processor_count-chars.go
@@ -22,19 +22,27 @@ var countCharsCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.CountCharacters{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_count-lines.go
+++ b/cmd/processor_count-lines.go
@@ -22,19 +22,27 @@ var countLinesCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.CountLines{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_count-words.go
+++ b/cmd/processor_count-words.go
@@ -22,19 +22,27 @@ var countWordsCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.CountWords{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_extract-emails.go
+++ b/cmd/processor_extract-emails.go
@@ -25,19 +25,27 @@ var extractEmailsCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.ExtractEmails{}
 		flags = append(flags, processors.Flag{Short: "s", Value: extractEmails_flag_s})
 

--- a/cmd/processor_hex-encode.go
+++ b/cmd/processor_hex-encode.go
@@ -22,19 +22,27 @@ var hexEncodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.HexEncode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_hex-rgb.go
+++ b/cmd/processor_hex-rgb.go
@@ -22,19 +22,27 @@ var hexRgbCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.HexToRGB{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_html-decode.go
+++ b/cmd/processor_html-decode.go
@@ -22,19 +22,27 @@ var htmlDecodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.HTMLDecode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_html-encode.go
+++ b/cmd/processor_html-encode.go
@@ -22,19 +22,27 @@ var htmlEncodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.HTMLEncode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_json-yaml.go
+++ b/cmd/processor_json-yaml.go
@@ -22,19 +22,27 @@ var jsonYamlCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.JSONToYAML{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_json.go
+++ b/cmd/processor_json.go
@@ -25,19 +25,27 @@ var jsonCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.FormatJSON{}
 		flags = append(flags, processors.Flag{Short: "i", Value: json_flag_i})
 

--- a/cmd/processor_kebab.go
+++ b/cmd/processor_kebab.go
@@ -22,19 +22,27 @@ var kebabCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Kebab{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_lower.go
+++ b/cmd/processor_lower.go
@@ -22,19 +22,27 @@ var lowerCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Lower{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_markdown-html.go
+++ b/cmd/processor_markdown-html.go
@@ -22,19 +22,27 @@ var markdownHtmlCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Markdown{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_md5.go
+++ b/cmd/processor_md5.go
@@ -22,19 +22,27 @@ var md5Cmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.MD5{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_reverse.go
+++ b/cmd/processor_reverse.go
@@ -22,19 +22,27 @@ var reverseCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Reverse{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_rot13-encode.go
+++ b/cmd/processor_rot13-encode.go
@@ -22,19 +22,27 @@ var rot13EncodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.ROT13Encode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_sha1.go
+++ b/cmd/processor_sha1.go
@@ -22,19 +22,27 @@ var sha1Cmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.SHA1{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_sha256.go
+++ b/cmd/processor_sha256.go
@@ -22,19 +22,27 @@ var sha256Cmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.SHA256{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_sha512.go
+++ b/cmd/processor_sha512.go
@@ -22,19 +22,27 @@ var sha512Cmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.SHA512{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_slug.go
+++ b/cmd/processor_slug.go
@@ -22,19 +22,27 @@ var slugCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Slug{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_snake.go
+++ b/cmd/processor_snake.go
@@ -22,19 +22,27 @@ var snakeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Snake{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_title.go
+++ b/cmd/processor_title.go
@@ -22,19 +22,27 @@ var titleCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Title{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_upper.go
+++ b/cmd/processor_upper.go
@@ -22,19 +22,27 @@ var upperCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Upper{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_url-decode.go
+++ b/cmd/processor_url-decode.go
@@ -22,19 +22,27 @@ var urlDecodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.URLDecode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_url-encode.go
+++ b/cmd/processor_url-encode.go
@@ -22,19 +22,27 @@ var urlEncodeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.URLEncode{}
 
 		out, err = p.Transform(in, flags...)

--- a/cmd/processor_yaml-json.go
+++ b/cmd/processor_yaml-json.go
@@ -25,19 +25,27 @@ var yamlJsonCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.YAMLToJSON{}
 		flags = append(flags, processors.Flag{Short: "i", Value: yamlJson_flag_i})
 

--- a/cmd/processor_zeropad.go
+++ b/cmd/processor_zeropad.go
@@ -29,19 +29,27 @@ var zeropadCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
-		in, out := "", ""
+		var in []byte
+		var out string
 
-		flags := make([]processors.Flag, 0)
 		if len(args) == 0 {
-			all, err := ioutil.ReadAll(cmd.InOrStdin())
+			in, err = ioutil.ReadAll(cmd.InOrStdin())
 			if err != nil {
 				return err
 			}
-			in = string(all)
 		} else {
-			in = args[0]
+			if fi, err := os.Stat(args[0]); err == nil && !fi.IsDir() {
+				d, err := ioutil.ReadFile(args[0])
+				if err != nil {
+					return err
+				}
+				in = d
+			} else {
+				in = []byte(args[0])
+			}
 		}
 
+		flags := make([]processors.Flag, 0)
 		p := processors.Zeropad{}
 		flags = append(flags, processors.Flag{Short: "n", Value: zeropad_flag_n})
 		flags = append(flags, processors.Flag{Short: "p", Value: zeropad_flag_p})

--- a/processors/base32.go
+++ b/processors/base32.go
@@ -15,8 +15,8 @@ func (p Base32Encoding) Alias() []string {
 	return []string{"b32-enc", "b32-encode"}
 }
 
-func (p Base32Encoding) Transform(data string, _ ...Flag) (string, error) {
-	return base32.StdEncoding.EncodeToString([]byte(data)), nil
+func (p Base32Encoding) Transform(data []byte, _ ...Flag) (string, error) {
+	return base32.StdEncoding.EncodeToString(data), nil
 }
 
 func (p Base32Encoding) Flags() []Flag {
@@ -46,8 +46,8 @@ func (p Base32Decode) Alias() []string {
 	return []string{"b32-dec", "b32-decode"}
 }
 
-func (p Base32Decode) Transform(data string, _ ...Flag) (string, error) {
-	decodedString, err := base32.StdEncoding.DecodeString(data)
+func (p Base32Decode) Transform(data []byte, _ ...Flag) (string, error) {
+	decodedString, err := base32.StdEncoding.DecodeString(string(data))
 	return string(decodedString), err
 }
 

--- a/processors/base32_test.go
+++ b/processors/base32_test.go
@@ -44,7 +44,7 @@ func TestBase32Encode_Command(t *testing.T) {
 
 func TestBase32Encode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -55,15 +55,15 @@ func TestBase32Encode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "ORUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEBQSA3DBPJ4SAZDPM4======",
 		}, {
 			name: "Emoji",
-			args: args{data: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "6CPZRA7QT6MIP4E7TGB7BH4ZQLYJ7GEJ6CPZRDHQT6MJT4E7TCL7BH4HV3YJ7B5T",
 		}, {
 			name: "Multi line string",
-			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "GEZDGMZUGUFGCYTDMQFDINJWBIYTEMYKMFRGGCRVGY3QUNZYHEYA====",
 		},
 	}
@@ -121,7 +121,7 @@ func TestBase32Decode_Command(t *testing.T) {
 
 func TestBase32Decode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -132,15 +132,15 @@ func TestBase32Decode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "ORUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEBQSA3DBPJ4SAZDPM4======"},
+			args: args{data: []byte("ORUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEBQSA3DBPJ4SAZDPM4======")},
 			want: "the quick brown fox jumps over a lazy dog",
 		}, {
 			name: "Emoji",
-			args: args{data: "6CPZRA7QT6MIP4E7TGB7BH4ZQLYJ7GEJ6CPZRDHQT6MJT4E7TCL7BH4HV3YJ7B5T"},
+			args: args{data: []byte("6CPZRA7QT6MIP4E7TGB7BH4ZQLYJ7GEJ6CPZRDHQT6MJT4E7TCL7BH4HV3YJ7B5T")},
 			want: "😃😇🙃🙂😉😌😙😗🇮🇳",
 		}, {
 			name: "Multi line string",
-			args: args{data: "GEZDGMZUGUFGCYTDMQFDINJWBIYTEMYKMFRGGCRVGY3QUNZYHEYA===="},
+			args: args{data: []byte("GEZDGMZUGUFGCYTDMQFDINJWBIYTEMYKMFRGGCRVGY3QUNZYHEYA====")},
 			want: "123345\nabcd\n456\n123\nabc\n567\n7890",
 		},
 	}

--- a/processors/base64.go
+++ b/processors/base64.go
@@ -15,8 +15,8 @@ func (p Base64Encode) Alias() []string {
 	return []string{"b64-enc", "b64-encode"}
 }
 
-func (p Base64Encode) Transform(data string, _ ...Flag) (string, error) {
-	return base64.StdEncoding.EncodeToString([]byte(data)), nil
+func (p Base64Encode) Transform(data []byte, _ ...Flag) (string, error) {
+	return base64.StdEncoding.EncodeToString(data), nil
 }
 
 func (p Base64Encode) Flags() []Flag {
@@ -46,8 +46,8 @@ func (p Base64Decode) Alias() []string {
 	return []string{"b64-dec", "b64-decode"}
 }
 
-func (p Base64Decode) Transform(data string, _ ...Flag) (string, error) {
-	decodedString, err := base64.StdEncoding.DecodeString(data)
+func (p Base64Decode) Transform(data []byte, _ ...Flag) (string, error) {
+	decodedString, err := base64.StdEncoding.DecodeString(string(data))
 	return string(decodedString), err
 }
 

--- a/processors/base64_test.go
+++ b/processors/base64_test.go
@@ -44,7 +44,7 @@ func TestBase64Encode_Command(t *testing.T) {
 
 func TestBase64Encode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -55,15 +55,15 @@ func TestBase64Encode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIGEgbGF6eSBkb2c=",
 		}, {
 			name: "Emoji",
-			args: args{data: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "8J+Yg/CfmIfwn5mD8J+ZgvCfmInwn5iM8J+YmfCfmJfwn4eu8J+Hsw==",
 		}, {
 			name: "Multi line string",
-			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "MTIzMzQ1CmFiY2QKNDU2CjEyMwphYmMKNTY3Cjc4OTA=",
 		},
 	}
@@ -121,7 +121,7 @@ func TestBase64Decode_Command(t *testing.T) {
 
 func TestBase64Decode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -132,15 +132,15 @@ func TestBase64Decode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIGEgbGF6eSBkb2c="},
+			args: args{data: []byte("dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIGEgbGF6eSBkb2c=")},
 			want: "the quick brown fox jumps over a lazy dog",
 		}, {
 			name: "Emoji",
-			args: args{data: "8J+Yg/CfmIfwn5mD8J+ZgvCfmInwn5iM8J+YmfCfmJfwn4eu8J+Hsw=="},
+			args: args{data: []byte("8J+Yg/CfmIfwn5mD8J+ZgvCfmInwn5iM8J+YmfCfmJfwn4eu8J+Hsw==")},
 			want: "😃😇🙃🙂😉😌😙😗🇮🇳",
 		}, {
 			name: "Multi line string",
-			args: args{data: "MTIzMzQ1CmFiY2QKNDU2CjEyMwphYmMKNTY3Cjc4OTA="},
+			args: args{data: []byte("MTIzMzQ1CmFiY2QKNDU2CjEyMwphYmMKNTY3Cjc4OTA=")},
 			want: "123345\nabcd\n456\n123\nabc\n567\n7890",
 		},
 	}

--- a/processors/crypto.go
+++ b/processors/crypto.go
@@ -21,9 +21,10 @@ func (p MD5) Alias() []string {
 	return []string{"md5-sum"}
 }
 
-func (p MD5) Transform(data string, f ...Flag) (string, error) {
+func (p MD5) Transform(data []byte, _ ...Flag) (string, error) {
+
 	hasher := md5.New()
-	hasher.Write([]byte(data))
+	hasher.Write(data)
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
@@ -55,9 +56,9 @@ func (p SHA1) Alias() []string {
 	return []string{"sha1-sum"}
 }
 
-func (p SHA1) Transform(data string, f ...Flag) (string, error) {
+func (p SHA1) Transform(data []byte, _ ...Flag) (string, error) {
 	h := sha1.New()
-	h.Write([]byte(data))
+	h.Write(data)
 	bs := h.Sum(nil)
 
 	return fmt.Sprintf("%x", bs), nil
@@ -90,9 +91,9 @@ func (p SHA256) Alias() []string {
 	return []string{"sha256-sum"}
 }
 
-func (p SHA256) Transform(data string, f ...Flag) (string, error) {
+func (p SHA256) Transform(data []byte, _ ...Flag) (string, error) {
 	h := sha256.New()
-	h.Write([]byte(data))
+	h.Write(data)
 	bs := h.Sum(nil)
 
 	return fmt.Sprintf("%x", bs), nil
@@ -125,9 +126,9 @@ func (p SHA512) Alias() []string {
 	return []string{"sha512-sum"}
 }
 
-func (p SHA512) Transform(data string, f ...Flag) (string, error) {
+func (p SHA512) Transform(data []byte, _ ...Flag) (string, error) {
 	h := sha512.New()
-	h.Write([]byte(data))
+	h.Write(data)
 	bs := h.Sum(nil)
 
 	return fmt.Sprintf("%x", bs), nil
@@ -160,7 +161,7 @@ func (p Bcrypt) Alias() []string {
 	return []string{"bcrypt-hash"}
 }
 
-func (p Bcrypt) Transform(data string, f ...Flag) (string, error) {
+func (p Bcrypt) Transform(data []byte, f ...Flag) (string, error) {
 	var rounds uint
 	for _, flag := range f {
 		if flag.Short == "r" {
@@ -171,7 +172,7 @@ func (p Bcrypt) Transform(data string, f ...Flag) (string, error) {
 		}
 	}
 
-	bytes, err := bcrypt.GenerateFromPassword([]byte(data), int(rounds))
+	bytes, err := bcrypt.GenerateFromPassword(data, int(rounds))
 
 	return string(bytes), err
 }
@@ -183,7 +184,7 @@ func (p Bcrypt) Flags() []Flag {
 			Short: "r",
 			Desc:  "Number of rounds",
 			Value: 10,
-			Type:  FlagUInt,
+			Type:  FlagUint,
 		},
 	}
 }

--- a/processors/crypto_test.go
+++ b/processors/crypto_test.go
@@ -67,9 +67,33 @@ func TestMD5Encode_Transform(t *testing.T) {
 			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "4da14107f15ce261f2641ab7b8769466",
 		}, {
-			name: "Trimmed linebreak",
-			args: args{data: []byte("Hello World\n")},
-			want: "e59ff97941044f85df5297e1c302d260",
+			name: "empty rfc1321", // test values from https://datatracker.ietf.org/doc/html/rfc1321
+			args: args{data: []byte("")},
+			want: "d41d8cd98f00b204e9800998ecf8427e",
+		}, {
+			name: "a rfc1321", // test values from https://datatracker.ietf.org/doc/html/rfc1321
+			args: args{data: []byte("a")},
+			want: "0cc175b9c0f1b6a831c399e269772661",
+		},{
+			name: "abc rfc1321", // test values from https://datatracker.ietf.org/doc/html/rfc1321
+			args: args{data: []byte("abc")},
+			want: "900150983cd24fb0d6963f7d28e17f72",
+		},{
+			name: "message digest rfc1321", // test values from https://datatracker.ietf.org/doc/html/rfc1321
+			args: args{data: []byte("message digest")},
+			want: "f96b697d7cb7938d525a2f31aaf161d0",
+		},{
+			name: "abcdefghijklmnopqrstuvwxyz rfc1321", // test values from https://datatracker.ietf.org/doc/html/rfc1321
+			args: args{data: []byte("abcdefghijklmnopqrstuvwxyz")},
+			want: "c3fcd3d76192e4007dfb496cca67e13b",
+		},{
+			name: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 rfc1321", // test values from https://datatracker.ietf.org/doc/html/rfc1321
+			args: args{data: []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")},
+			want: "d174ab98d277d9f5a5611c2c9f419d9f",
+		},{
+			name: "12345678901234567890123456789012345678901234567890123456789012345678901234567890 rfc1321", // test values from https://datatracker.ietf.org/doc/html/rfc1321
+			args: args{data: []byte("12345678901234567890123456789012345678901234567890123456789012345678901234567890")},
+			want: "57edf4a22be3c955ac49da2e2107b67a",
 		},
 	}
 	for _, tt := range tests {

--- a/processors/crypto_test.go
+++ b/processors/crypto_test.go
@@ -45,7 +45,7 @@ func TestMD5Encode_Command(t *testing.T) {
 
 func TestMD5Encode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -56,19 +56,19 @@ func TestMD5Encode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "f3e7b7426c27a59d36cf9fe9db5a1a1b",
 		}, {
 			name: "Emoji",
-			args: args{data: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "028990045a146ff3abbc0ba9ab772d84",
 		}, {
 			name: "Multi line string",
-			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "4da14107f15ce261f2641ab7b8769466",
 		}, {
 			name: "Trimmed linebreak",
-			args: args{data: "Hello World\n"},
+			args: args{data: []byte("Hello World\n")},
 			want: "e59ff97941044f85df5297e1c302d260",
 		},
 	}
@@ -126,7 +126,7 @@ func TestSHA1Encode_Command(t *testing.T) {
 
 func TestSHA1Encode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -137,19 +137,19 @@ func TestSHA1Encode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "dcab639dcb4bf4d577d396758ebf91b6939e732a",
 		}, {
 			name: "Emoji",
-			args: args{data: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "c07a5913366f3fa980e2520089e1642d28edc116",
 		}, {
 			name: "Multi line string",
-			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "6dfc74a3e7472a8ca5794962b62b144a82808e2c",
 		}, {
 			name: "Trimmed linebreak",
-			args: args{data: "Hello World\n"},
+			args: args{data: []byte("Hello World\n")},
 			want: "648a6a6ffffdaa0badb23b8baf90b6168dd16b3a",
 		},
 	}
@@ -207,7 +207,7 @@ func TestSHA256Encode_Command(t *testing.T) {
 
 func TestSHA256Encode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -218,19 +218,19 @@ func TestSHA256Encode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "883238e6c74b0b4838738c5117bef8660fb9207877603fbfd7fe5c8ab9e579a1",
 		}, {
 			name: "Emoji",
-			args: args{data: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "29298957699f889a8dd88d6239ba927c01cca0dbdcccf2730cfc7533ed633f21",
 		}, {
 			name: "Multi line string",
-			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "a5deaf4214a6cf73c20bfb6df0a0ec1d0ade6b3fe7d1845592e49d06082fa039",
 		}, {
 			name: "Trimmed linebreak",
-			args: args{data: "Hello World\n"},
+			args: args{data: []byte("Hello World\n")},
 			want: "d2a84f4b8b650937ec8f73cd8be2c74add5a911ba64df27458ed8229da804a26",
 		},
 	}
@@ -288,7 +288,7 @@ func TestSHA512Encode_Command(t *testing.T) {
 
 func TestSHA512Encode_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -299,19 +299,19 @@ func TestSHA512Encode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "db9bf1e67167b9bd6573386cc212f3e0ad3f701f0c2e9779d0b752062bf38e62c205a3c02816b92ef3c4f9004f793ea9b92d99813134535ddc9cfde970f8131c",
 		}, {
 			name: "Emoji",
-			args: args{data: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "e34072a7584c345d5baf2296a9e966b86329e8bee04a546f265f96f23e09152a9aedce87d36b7ef2859273d10eaa99ecac6261997c19b0d7858284aaa1e58056",
 		}, {
 			name: "Multi line string",
-			args: args{data: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "aa53744b761ea00e61737ff65bee640519c21ce1850898a9dfd285057bba9a0cf2a9ba512dcdc1f5c8f6df0666336249495153b3875fa74f32b5e612f858f553",
 		}, {
 			name: "Trimmed linebreak",
-			args: args{data: "Hello World\n"},
+			args: args{data: []byte("Hello World\n")},
 			want: "e1c112ff908febc3b98b1693a6cd3564eaf8e5e6ca629d084d9f0eba99247cacdd72e369ff8941397c2807409ff66be64be908da17ad7b8a49a2a26c0e8086aa",
 		},
 	}
@@ -348,7 +348,7 @@ func TestBcrypt_Command(t *testing.T) {
 				Short: "r",
 				Desc:  "Number of rounds",
 				Value: 10,
-				Type:  FlagUInt,
+				Type:  FlagUint,
 			},
 		},
 		name:  "bcrypt",
@@ -377,7 +377,7 @@ func TestBcrypt_Command(t *testing.T) {
 
 func TestBcrypt_Transform(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -388,11 +388,11 @@ func TestBcrypt_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 		},
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog", in1: []Flag{{Value: 12}}},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog"), in1: []Flag{{Value: 12}}},
 		},
 	}
 	for _, tt := range tests {

--- a/processors/hex.go
+++ b/processors/hex.go
@@ -12,8 +12,8 @@ func (p HexEncode) Alias() []string {
 	return []string{"hex-enc", "hexadecimal-encode"}
 }
 
-func (p HexEncode) Transform(input string, _ ...Flag) (string, error) {
-	return hex.EncodeToString([]byte(input)), nil
+func (p HexEncode) Transform(data []byte, _ ...Flag) (string, error) {
+	return hex.EncodeToString(data), nil
 }
 
 func (p HexEncode) Flags() []Flag {
@@ -42,8 +42,8 @@ func (p HexDecode) Alias() []string {
 	return []string{"hex-dec", "hexadecimal-decode"}
 }
 
-func (p HexDecode) Transform(input string, _ ...Flag) (string, error) {
-	output, err := hex.DecodeString(input)
+func (p HexDecode) Transform(data []byte, _ ...Flag) (string, error) {
+	output, err := hex.DecodeString(string(data))
 
 	if err != nil {
 		return "", err

--- a/processors/hex_test.go
+++ b/processors/hex_test.go
@@ -44,7 +44,7 @@ func TestHexEncode_Command(t *testing.T) {
 
 func TestHexEncode_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -55,31 +55,31 @@ func TestHexEncode_Transform(t *testing.T) {
 	}{
 		{
 			name: "Test empty string",
-			args: args{input: ""},
+			args: args{data: []byte("")},
 			want: "",
 		},
 		{
 			name: "String",
-			args: args{input: "this is string"},
+			args: args{data: []byte("this is string")},
 			want: "7468697320697320737472696e67",
 		}, {
 			name: "Emoji",
-			args: args{input: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "f09f9883f09f9887f09f9983f09f9982f09f9889f09f988cf09f9899f09f9897f09f87aef09f87b3",
 		}, {
 			name: "Multi line string",
-			args: args{input: "Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***"},
+			args: args{data: []byte("Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***")},
 			want: "48656c6c6f0a666f6f0a6261720a666f6f0a6630300a252a265e2a265e260a2a2a2a",
 		}, {
 			name: "Test multi lingual character",
-			args: args{input: "नमस्ते"},
+			args: args{data: []byte("नमस्ते")},
 			want: "e0a4a8e0a4aee0a4b8e0a58de0a4a4e0a587",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := HexEncode{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -130,7 +130,7 @@ func TestHexDecode_Command(t *testing.T) {
 
 func TestHexDecode_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -141,34 +141,34 @@ func TestHexDecode_Transform(t *testing.T) {
 	}{
 		{
 			name:    "Test empty hex",
-			args:    args{input: ""},
+			args:    args{data: []byte("")},
 			want:    "",
 			wantErr: false,
 		},
 		{
 			name:    "Test invalid hex",
-			args:    args{input: "this is invalid hex"},
+			args:    args{data: []byte("this is invalid hex")},
 			want:    "",
 			wantErr: true,
 		},
 		{
 			name: "String",
-			args: args{input: "7468697320697320737472696e67"},
+			args: args{data: []byte("7468697320697320737472696e67")},
 			want: "this is string",
 		}, {
 			name: "Emoji",
-			args: args{input: "f09f9883f09f9887f09f9983f09f9982f09f9889f09f988cf09f9899f09f9897f09f87aef09f87b3"},
+			args: args{data: []byte("f09f9883f09f9887f09f9983f09f9982f09f9889f09f988cf09f9899f09f9897f09f87aef09f87b3")},
 			want: "😃😇🙃🙂😉😌😙😗🇮🇳",
 		}, {
 			name: "Multi line string",
-			args: args{input: "48656c6c6f0a666f6f0a6261720a666f6f0a6630300a252a265e2a265e260a2a2a2a"},
+			args: args{data: []byte("48656c6c6f0a666f6f0a6261720a666f6f0a6630300a252a265e2a265e260a2a2a2a")},
 			want: "Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := HexDecode{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/processors/html.go
+++ b/processors/html.go
@@ -14,8 +14,8 @@ func (p HTMLEncode) Alias() []string {
 	return []string{"html-enc", "html-escape"}
 }
 
-func (p HTMLEncode) Transform(input string, _ ...Flag) (string, error) {
-	return html.EscapeString(input), nil
+func (p HTMLEncode) Transform(data []byte, _ ...Flag) (string, error) {
+	return html.EscapeString(string(data)), nil
 }
 
 func (p HTMLEncode) Flags() []Flag {
@@ -44,8 +44,8 @@ func (p HTMLDecode) Alias() []string {
 	return []string{"html-dec", "html-unescape"}
 }
 
-func (p HTMLDecode) Transform(input string, _ ...Flag) (string, error) {
-	return html.UnescapeString(input), nil
+func (p HTMLDecode) Transform(data []byte, _ ...Flag) (string, error) {
+	return html.UnescapeString(string(data)), nil
 }
 
 func (p HTMLDecode) Flags() []Flag {

--- a/processors/html_test.go
+++ b/processors/html_test.go
@@ -44,7 +44,7 @@ func TestHTMLEncode_Command(t *testing.T) {
 
 func TestHTMLEncode_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -55,7 +55,7 @@ func TestHTMLEncode_Transform(t *testing.T) {
 	}{
 		{
 			name: "Should escape HTML",
-			args: args{input: `<!DOCTYPE html>
+			args: args{data: []byte(`<!DOCTYPE html>
 <html>
 <body>
 
@@ -64,7 +64,7 @@ func TestHTMLEncode_Transform(t *testing.T) {
 <p>My first paragraph.</p>
 
 </body>
-</html>`},
+</html>`)},
 			want: `&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;body&gt;
@@ -79,7 +79,7 @@ func TestHTMLEncode_Transform(t *testing.T) {
 		},
 		{
 			name:    "should escape xss string",
-			args:    args{input: `<script>alert("XSS");</script>`},
+			args:    args{data: []byte(`<script>alert("XSS");</script>`)},
 			want:    `&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;`,
 			wantErr: false,
 		},
@@ -87,7 +87,7 @@ func TestHTMLEncode_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := HTMLEncode{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -138,7 +138,7 @@ func TestHTMLDecode_Command(t *testing.T) {
 
 func TestHTMLDecode_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -149,7 +149,7 @@ func TestHTMLDecode_Transform(t *testing.T) {
 	}{
 		{
 			name: "Should unescape HTML",
-			args: args{input: `&lt;!DOCTYPE html&gt;
+			args: args{data: []byte(`&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;body&gt;
 
@@ -158,7 +158,7 @@ func TestHTMLDecode_Transform(t *testing.T) {
 &lt;p&gt;My first paragraph.&lt;/p&gt;
 
 &lt;/body&gt;
-&lt;/html&gt;`},
+&lt;/html&gt;`)},
 			want: `<!DOCTYPE html>
 <html>
 <body>
@@ -173,7 +173,7 @@ func TestHTMLDecode_Transform(t *testing.T) {
 		},
 		{
 			name:    "should unescape xss string",
-			args:    args{input: `&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;`},
+			args:    args{data: []byte(`&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;`)},
 			want:    `<script>alert("XSS");</script>`,
 			wantErr: false,
 		},
@@ -181,7 +181,7 @@ func TestHTMLDecode_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := HTMLDecode{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/processors/json.go
+++ b/processors/json.go
@@ -16,9 +16,9 @@ func (p FormatJSON) Alias() []string {
 	return nil
 }
 
-func (p FormatJSON) Transform(input string, f ...Flag) (string, error) {
+func (p FormatJSON) Transform(data []byte, f ...Flag) (string, error) {
 	var objmap map[string]*json.RawMessage
-	err := json.Unmarshal([]byte(input), &objmap)
+	err := json.Unmarshal(data, &objmap)
 	if err != nil {
 		return "", err
 	}
@@ -70,8 +70,8 @@ func (p JSONToYAML) Alias() []string {
 	return []string{"json-yml"}
 }
 
-func (p JSONToYAML) Transform(input string, _ ...Flag) (string, error) {
-	y, err := yaml.JSONToYAML([]byte(input))
+func (p JSONToYAML) Transform(data []byte, _ ...Flag) (string, error) {
+	y, err := yaml.JSONToYAML(data)
 	if err != nil {
 		return "", err
 	}
@@ -105,13 +105,13 @@ func (p YAMLToJSON) Alias() []string {
 	return []string{"yml-json"}
 }
 
-func (p YAMLToJSON) Transform(input string, f ...Flag) (string, error) {
-	y, err := yaml.YAMLToJSON([]byte(input))
+func (p YAMLToJSON) Transform(data []byte, f ...Flag) (string, error) {
+	y, err := yaml.YAMLToJSON(data)
 	if err != nil {
 		return "", err
 	}
 	j := FormatJSON{}
-	return j.Transform(string(y), f...)
+	return j.Transform(y, f...)
 }
 
 func (p YAMLToJSON) Flags() []Flag {

--- a/processors/markdown.go
+++ b/processors/markdown.go
@@ -16,9 +16,9 @@ func (p Markdown) Alias() []string {
 	return []string{"md-html"}
 }
 
-func (p Markdown) Transform(input string, _ ...Flag) (string, error) {
+func (p Markdown) Transform(data []byte, _ ...Flag) (string, error) {
 	var buf bytes.Buffer
-	if err := goldmark.Convert([]byte(input), &buf); err != nil {
+	if err := goldmark.Convert(data, &buf); err != nil {
 		return "", err
 	}
 	return buf.String(), nil

--- a/processors/markdown_test.go
+++ b/processors/markdown_test.go
@@ -44,7 +44,7 @@ func TestMarkdown_Command(t *testing.T) {
 
 func TestMarkdown_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -55,24 +55,24 @@ func TestMarkdown_Transform(t *testing.T) {
 	}{
 		{
 			name: "test empty string",
-			args: args{input: ""},
+			args: args{data: []byte("")},
 			want: "",
 		},
 		{
 			name: "test H1",
-			args: args{input: "# H1"},
+			args: args{data: []byte("# H1")},
 			want: "<h1>H1</h1>\n",
 		},
 		{
 			name: "test bold",
-			args: args{input: "**the quick brown fox jumps over a lazy dog**"},
+			args: args{data: []byte("**the quick brown fox jumps over a lazy dog**")},
 			want: "<p><strong>the quick brown fox jumps over a lazy dog</strong></p>\n",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Markdown{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -61,6 +61,7 @@ type Processor interface {
 }
 
 type FlagType string
+const FlagFile = "file"
 
 func (f FlagType) String() string {
 	return string(f)
@@ -92,6 +93,18 @@ type Flag struct {
 
 	// Value - optional default value of the flag
 	Value interface{}
+}
+
+func fromFile(flags []Flag) bool {
+	for _, flag := range flags {
+		if flag.Short == FlagFile {
+			if b, ok := flag.Value.(bool); ok {
+				return b
+			}
+			return false
+		}
+	}
+	return false
 }
 
 // Zeropad is an Example processor to show how to add text processors,

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -109,16 +109,16 @@ func (p Zeropad) Alias() []string {
 	return nil
 }
 
-func (p Zeropad) Transform(input string, f ...Flag) (string, error) {
-	input = strings.TrimSpace(input)
+func (p Zeropad) Transform(data []byte, f ...Flag) (string, error) {
+	strIn := strings.TrimSpace(string(data))
 	neg := ""
-	i, err := strconv.ParseFloat(input, 64)
+	i, err := strconv.ParseFloat(strIn, 64)
 	if err != nil {
-		return "", fmt.Errorf("number expected: '%s'", input)
+		return "", fmt.Errorf("number expected: '%s'", data)
 	}
 	if i < 0 {
 		neg = "-"
-		input = input[1:]
+		data = data[1:]
 	}
 
 	n := 1
@@ -136,7 +136,7 @@ func (p Zeropad) Transform(input string, f ...Flag) (string, error) {
 			}
 		}
 	}
-	return fmt.Sprintf("%s%s%s%s", pre, neg, strings.Repeat("0", n), input), nil
+	return fmt.Sprintf("%s%s%s%s", pre, neg, strings.Repeat("0", n), data), nil
 }
 
 func (p Zeropad) Flags() []Flag {

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -61,7 +61,6 @@ type Processor interface {
 }
 
 type FlagType string
-const FlagFile = "file"
 
 func (f FlagType) String() string {
 	return string(f)
@@ -93,18 +92,6 @@ type Flag struct {
 
 	// Value - optional default value of the flag
 	Value interface{}
-}
-
-func fromFile(flags []Flag) bool {
-	for _, flag := range flags {
-		if flag.Short == FlagFile {
-			if b, ok := flag.Value.(bool); ok {
-				return b
-			}
-			return false
-		}
-	}
-	return false
 }
 
 // Zeropad is an Example processor to show how to add text processors,

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -54,7 +54,7 @@ type Processor interface {
 	Alias() []string
 
 	// Transform is the text transformation function, implemented by the processor
-	Transform(input string, opts ...Flag) (string, error)
+	Transform(data []byte, opts ...Flag) (string, error)
 
 	// Flags are flags that could be used to transform the text
 	Flags() []Flag

--- a/processors/processor.go
+++ b/processors/processor.go
@@ -71,10 +71,9 @@ func (f FlagType) IsString() bool {
 }
 
 const (
-	FlagUInt   = FlagType("Uint")
-	FlagInt    = FlagType("Int")
-	FlagUint   = FlagType("Uint")
-	FlagBool   = FlagType("Bool")
+	FlagInt  = FlagType("Int")
+	FlagUint = FlagType("Uint")
+	FlagBool = FlagType("Bool")
 	FlagString = FlagType("String")
 )
 
@@ -147,7 +146,7 @@ func (p Zeropad) Flags() []Flag {
 			Short: "n",
 			Desc:  "Number of zeros to be padded",
 			Value: 5,
-			Type:  FlagUInt,
+			Type:  FlagUint,
 		},
 		{
 			Name:  "prefix",

--- a/processors/rgb.go
+++ b/processors/rgb.go
@@ -18,8 +18,8 @@ func (p HexToRGB) Alias() []string {
 	return nil
 }
 
-func (p HexToRGB) Transform(input string, _ ...Flag) (string, error) {
-	c, err := colorful.Hex(input)
+func (p HexToRGB) Transform(data []byte, _ ...Flag) (string, error) {
+	c, err := colorful.Hex(string(data))
 	return fmt.Sprintf("%d, %d, %d", int(c.R*255), int(c.G*255), int(c.B*255)), err
 }
 

--- a/processors/rgb_test.go
+++ b/processors/rgb_test.go
@@ -44,7 +44,7 @@ func TestRGB_Command(t *testing.T) {
 
 func TestHexToRGB_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -55,18 +55,18 @@ func TestHexToRGB_Transform(t *testing.T) {
 	}{
 		{
 			name: "Hex with # string",
-			args: args{input: "#FF5733"},
+			args: args{data: []byte("#FF5733")},
 			want: "255, 87, 51",
 		},
 		{
 			name:    "HEX string with wrong string",
-			args:    args{input: "#PPPPP"},
+			args:    args{data: []byte("#PPPPP")},
 			want:    "0, 0, 0",
 			wantErr: true,
 		},
 		{
 			name:    "HEX string with wrong string",
-			args:    args{input: "FF5733"},
+			args:    args{data: []byte("FF5733")},
 			want:    "0, 0, 0",
 			wantErr: true,
 		},
@@ -74,7 +74,7 @@ func TestHexToRGB_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := HexToRGB{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/processors/rot.go
+++ b/processors/rot.go
@@ -13,8 +13,8 @@ func (p ROT13Encode) Alias() []string {
 	return []string{"rot13", "rot13-enc"}
 }
 
-func (p ROT13Encode) Transform(input string, _ ...Flag) (string, error) {
-	return strings.Map(rot13, input), nil
+func (p ROT13Encode) Transform(data []byte, _ ...Flag) (string, error) {
+	return strings.Map(rot13, string(data)), nil
 }
 
 func (p ROT13Encode) Flags() []Flag {

--- a/processors/rot_test.go
+++ b/processors/rot_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestROT13Encode_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -18,26 +18,26 @@ func TestROT13Encode_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "gur dhvpx oebja sbk wh`cf bire n ynml qbt",
 		}, {
 			name: "String Uppercase",
-			args: args{input: "THE QUICK BROWN FOX JUMPS OVER A LAZY DOG"},
+			args: args{data: []byte("THE QUICK BROWN FOX JUMPS OVER A LAZY DOG")},
 			want: "GUR DHVPX OEBJA SBK WH@CF BIRE N YNML QBT",
 		}, {
 			name: "Emoji",
-			args: args{input: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "😃😇🙃🙂😉😌😙😗🇮🇳",
 		}, {
 			name: "Multi line string",
-			args: args{input: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "123345\nnopq\n456\n123\nnop\n567\n7890",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := ROT13Encode{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/processors/strings.go
+++ b/processors/strings.go
@@ -24,8 +24,8 @@ func (p Lower) Alias() []string {
 	return nil
 }
 
-func (p Lower) Transform(input string, _ ...Flag) (string, error) {
-	return strings.ToLower(input), nil
+func (p Lower) Transform(data []byte, _ ...Flag) (string, error) {
+	return strings.ToLower(string(data)), nil
 }
 
 func (p Lower) Flags() []Flag {
@@ -56,8 +56,8 @@ func (p Upper) Alias() []string {
 	return nil
 }
 
-func (p Upper) Transform(input string, _ ...Flag) (string, error) {
-	return strings.ToUpper(input), nil
+func (p Upper) Transform(data []byte, _ ...Flag) (string, error) {
+	return strings.ToUpper(string(data)), nil
 }
 
 func (p Upper) Flags() []Flag {
@@ -88,8 +88,8 @@ func (p Title) Alias() []string {
 	return nil
 }
 
-func (p Title) Transform(input string, _ ...Flag) (string, error) {
-	return strings.Title(input), nil
+func (p Title) Transform(data []byte, _ ...Flag) (string, error) {
+	return strings.Title(string(data)), nil
 }
 
 func (p Title) Flags() []Flag {
@@ -120,9 +120,9 @@ func (p Snake) Alias() []string {
 	return nil
 }
 
-func (p Snake) Transform(input string, _ ...Flag) (string, error) {
-	input = regexp.MustCompile(`\s+`).ReplaceAllString(input, " ")
-	return strcase.ToSnake(input), nil
+func (p Snake) Transform(data []byte, _ ...Flag) (string, error) {
+	str := regexp.MustCompile(`\s+`).ReplaceAllString(string(data), " ")
+	return strcase.ToSnake(str), nil
 }
 
 func (p Snake) Flags() []Flag {
@@ -153,8 +153,8 @@ func (p Kebab) Alias() []string {
 	return nil
 }
 
-func (p Kebab) Transform(input string, _ ...Flag) (string, error) {
-	return utils.ToKebabCase(input), nil
+func (p Kebab) Transform(data []byte, _ ...Flag) (string, error) {
+	return utils.ToKebabCase(data), nil
 }
 
 func (p Kebab) Flags() []Flag {
@@ -185,9 +185,9 @@ func (p Camel) Alias() []string {
 	return nil
 }
 
-func (p Camel) Transform(input string, _ ...Flag) (string, error) {
-	input = regexp.MustCompile(`\s+`).ReplaceAllString(input, " ")
-	return strcase.ToCamel(input), nil
+func (p Camel) Transform(data []byte, _ ...Flag) (string, error) {
+	str := regexp.MustCompile(`\s+`).ReplaceAllString(string(data), " ")
+	return strcase.ToCamel(str), nil
 }
 
 func (p Camel) Flags() []Flag {
@@ -218,9 +218,9 @@ func (p Slug) Alias() []string {
 	return nil
 }
 
-func (p Slug) Transform(input string, _ ...Flag) (string, error) {
+func (p Slug) Transform(data []byte, _ ...Flag) (string, error) {
 	re := regexp.MustCompile("[^a-z0-9]+")
-	return strings.Trim(re.ReplaceAllString(strings.ToLower(input), "-"), "-"), nil
+	return strings.Trim(re.ReplaceAllString(strings.ToLower(string(data)), "-"), "-"), nil
 }
 
 func (p Slug) Flags() []Flag {
@@ -250,8 +250,8 @@ func (p CountCharacters) Alias() []string {
 	return nil
 }
 
-func (p CountCharacters) Transform(input string, _ ...Flag) (string, error) {
-	return fmt.Sprintf("%d", len([]rune(input))), nil
+func (p CountCharacters) Transform(data []byte, _ ...Flag) (string, error) {
+	return fmt.Sprintf("%d", len([]rune(string(data)))), nil
 }
 
 func (p CountCharacters) Flags() []Flag {
@@ -282,8 +282,8 @@ func (p CountWords) Alias() []string {
 	return nil
 }
 
-func (p CountWords) Transform(input string, _ ...Flag) (string, error) {
-	return fmt.Sprintf("%d", len(strings.Fields(input))), nil
+func (p CountWords) Transform(data []byte, _ ...Flag) (string, error) {
+	return fmt.Sprintf("%d", len(strings.Fields(string(data)))), nil
 }
 
 func (p CountWords) Flags() []Flag {
@@ -314,9 +314,9 @@ func (p CountLines) Alias() []string {
 	return nil
 }
 
-func (p CountLines) Transform(input string, _ ...Flag) (string, error) {
-	lines := strings.Count(input, "\n")
-	if len(input) > 0 && !strings.HasSuffix(input, "\n") {
+func (p CountLines) Transform(data []byte, _ ...Flag) (string, error) {
+	lines := strings.Count(string(data), "\n")
+	if len(data) > 0 && !strings.HasSuffix(string(data), "\n") {
 		lines++
 	}
 	return fmt.Sprintf("%d", lines), nil
@@ -350,8 +350,8 @@ func (p SortLines) Alias() []string {
 	return nil
 }
 
-func (p SortLines) Transform(input string, _ ...Flag) (string, error) {
-	sorted := strings.Split(input, "\n")
+func (p SortLines) Transform(data []byte, _ ...Flag) (string, error) {
+	sorted := strings.Split(string(data), "\n")
 	sort.Strings(sorted)
 	return strings.Join(sorted, "\n"), nil
 }
@@ -384,9 +384,9 @@ func (p Reverse) Alias() []string {
 	return nil
 }
 
-func (p Reverse) Transform(input string, _ ...Flag) (string, error) {
+func (p Reverse) Transform(data []byte, _ ...Flag) (string, error) {
 	result := ""
-	for _, v := range input {
+	for _, v := range data {
 		result = string(v) + result
 	}
 	return result, nil
@@ -419,9 +419,9 @@ func (p ExtractEmails) Alias() []string {
 	return []string{"find-emails", "find-email", "extract-email"}
 }
 
-func (p ExtractEmails) Transform(input string, f ...Flag) (string, error) {
+func (p ExtractEmails) Transform(data []byte, f ...Flag) (string, error) {
 	var emails []string
-	extracted := emailaddress.FindWithIcannSuffix([]byte(input), false)
+	extracted := emailaddress.FindWithIcannSuffix(data, false)
 	for _, e := range extracted {
 		emails = append(emails, e.String())
 	}

--- a/processors/strings_test.go
+++ b/processors/strings_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestCountCharacters_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -18,27 +18,27 @@ func TestCountCharacters_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "41",
 		}, {
 			name: "Emoji",
-			args: args{input: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "10",
 		}, {
 			name: "Multi line string",
-			args: args{input: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "32",
 		},
 		{
 			name: "Double-byte characters",
-			args: args{input: "你好"},
+			args: args{data: []byte("你好")},
 			want: "2",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := CountCharacters{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("CountCharacters() = %v, want %v", got, tt.want)
 			}
 		})
@@ -47,7 +47,7 @@ func TestCountCharacters_Transform(t *testing.T) {
 
 func TestSortLines_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -58,19 +58,19 @@ func TestSortLines_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***"},
+			args: args{data: []byte("Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***")},
 			want: "%*&^*&^&\n***\nHello\nbar\nf00\nfoo\nfoo",
 		},
 		{
 			name: "Numbers",
-			args: args{input: "3\n1\n6\n5\n9\n10\n4\n8\n7\n2"},
+			args: args{data: []byte("3\n1\n6\n5\n9\n10\n4\n8\n7\n2")},
 			want: "1\n10\n2\n3\n4\n5\n6\n7\n8\n9",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := SortLines{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("SortLines() = %v, want %v", got, tt.want)
 			}
 		})
@@ -79,7 +79,7 @@ func TestSortLines_Transform(t *testing.T) {
 
 func TestLower_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -90,22 +90,22 @@ func TestLower_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***"},
+			args: args{data: []byte("THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***")},
 			want: "the quick brown fox jumps over a lazy dog hello foo bar foo f00 %*&^*&^& ***",
 		}, {
 			name: "Emoji",
-			args: args{input: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "😃😇🙃🙂😉😌😙😗🇮🇳",
 		}, {
 			name: "Multi line string",
-			args: args{input: "Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***"},
+			args: args{data: []byte("Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***")},
 			want: "hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Lower{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("StringToLower() = %v, want %v", got, tt.want)
 			}
 		})
@@ -114,7 +114,7 @@ func TestLower_Transform(t *testing.T) {
 
 func TestTitle_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -125,18 +125,18 @@ func TestTitle_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "The Quick Brown Fox Jumps Over A Lazy Dog",
 		}, {
 			name: "String Uppercase",
-			args: args{input: "THE QUICK BROWN FOX JUMPS OVER A LAZY DOG"},
+			args: args{data: []byte("THE QUICK BROWN FOX JUMPS OVER A LAZY DOG")},
 			want: "THE QUICK BROWN FOX JUMPS OVER A LAZY DOG",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Title{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("StringToTitle() = %v, want %v", got, tt.want)
 			}
 		})
@@ -145,7 +145,7 @@ func TestTitle_Transform(t *testing.T) {
 
 func TestUpper_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -156,22 +156,22 @@ func TestUpper_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***"},
+			args: args{data: []byte("THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***")},
 			want: "THE QUICK BROWN FOX JUMPS OVER A LAZY DOG HELLO FOO BAR FOO F00 %*&^*&^& ***",
 		}, {
 			name: "Emoji",
-			args: args{input: "😃😇🙃🙂😉😌😙😗🇮🇳"},
+			args: args{data: []byte("😃😇🙃🙂😉😌😙😗🇮🇳")},
 			want: "😃😇🙃🙂😉😌😙😗🇮🇳",
 		}, {
 			name: "Multi line string",
-			args: args{input: "Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***"},
+			args: args{data: []byte("Hello\nfoo\nbar\nfoo\nf00\n%*&^*&^&\n***")},
 			want: "HELLO\nFOO\nBAR\nFOO\nF00\n%*&^*&^&\n***",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Upper{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("StringToUpper() = %v, want %v", got, tt.want)
 			}
 		})
@@ -180,7 +180,7 @@ func TestUpper_Transform(t *testing.T) {
 
 func TestSnakeCase_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -191,29 +191,29 @@ func TestSnakeCase_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***"},
+			args: args{data: []byte("THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***")},
 			want: "the_quick_brown_fox_jumps_over_a_lazy_dog_hello_foo_bar_foo_f_00_%*&^*&^&_***",
 		},
 		{
 			name: "TestStringExample",
-			args: args{input: "test_string_example"},
+			args: args{data: []byte("test_string_example")},
 			want: "test_string_example",
 		},
 		{
 			name: "Lots of Space",
-			args: args{input: "Lots    Of      Space   "},
+			args: args{data: []byte("Lots    Of      Space   ")},
 			want: "lots_of_space",
 		},
 		{
 			name: "Multi Line String",
-			args: args{input: "Multi\nLine\nString"},
+			args: args{data: []byte("Multi\nLine\nString")},
 			want: "multi_line_string",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Snake{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("StringToSnakeCase() = %v, want %v", got, tt.want)
 			}
 		})
@@ -259,7 +259,7 @@ func TestKebab_Command(t *testing.T) {
 
 func TestKebab_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -270,29 +270,29 @@ func TestKebab_Transform(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{input: "THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***"},
+			args: args{data: []byte("THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***")},
 			want: "the-quick-brown-fox-jumps-over-a-lazy-dog-hello-foo-bar-foo-f-00-%*&^*&^&-***",
 		},
 		{
 			name: "TestStringExample",
-			args: args{input: "test_string_example"},
+			args: args{data: []byte("test_string_example")},
 			want: "test-string-example",
 		},
 		{
 			name: "Lots of Space",
-			args: args{input: "Lots    Of      Space   "},
+			args: args{data: []byte("Lots    Of      Space   ")},
 			want: "lots-of-space",
 		},
 		{
 			name: "Multi Line String",
-			args: args{input: "Multi\nLine\nString"},
+			args: args{data: []byte("Multi\nLine\nString")},
 			want: "multi-line-string",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Kebab{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("StringToKebab() = %v, want %v", got, tt.want)
 			}
 		})
@@ -301,7 +301,7 @@ func TestKebab_Transform(t *testing.T) {
 
 func TestSlug_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -312,29 +312,29 @@ func TestSlug_Transform(t *testing.T) {
 	}{
 		{
 			name: "hello world",
-			args: args{input: "hello world"},
+			args: args{data: []byte("hello world")},
 			want: "hello-world",
 		},
 		{
 			name: "hello_world",
-			args: args{input: "hello_world"},
+			args: args{data: []byte("hello_world")},
 			want: "hello-world",
 		},
 		{
 			name: "Lots of Space",
-			args: args{input: "Lots    Of      Space   "},
+			args: args{data: []byte("Lots    Of      Space   ")},
 			want: "lots-of-space",
 		},
 		{
 			name: "String",
-			args: args{input: "THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***"},
+			args: args{data: []byte("THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***")},
 			want: "the-quick-brown-fox-jumps-over-a-lazy-dog-hello-foo-bar-foo-f00",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Slug{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("StringToSlug() = %v, want %v", got, tt.want)
 			}
 		})
@@ -343,7 +343,7 @@ func TestSlug_Transform(t *testing.T) {
 
 func TestStringReverse_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -354,34 +354,34 @@ func TestStringReverse_Transform(t *testing.T) {
 	}{
 		{
 			name: "hello world",
-			args: args{input: "hello world"},
+			args: args{data: []byte("hello world")},
 			want: "dlrow olleh",
 		},
 		{
 			name: "hello_world",
-			args: args{input: "hello_world"},
+			args: args{data: []byte("hello_world")},
 			want: "dlrow_olleh",
 		},
 		{
 			name: "Lots of Space",
-			args: args{input: "Lots    Of      Space   "},
+			args: args{data: []byte("Lots    Of      Space   ")},
 			want: "   ecapS      fO    stoL",
 		},
 		{
 			name: "String",
-			args: args{input: "THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***"},
+			args: args{data: []byte("THE quick brown fox jumps over a lazy dog Hello foo bar foo f00 %*&^*&^& ***")},
 			want: "*** &^&*^&*% 00f oof rab oof olleH god yzal a revo spmuj xof nworb kciuq EHT",
 		},
 		{
 			name: "Multi line string",
-			args: args{input: "123345\nabcd\n456\n123\nabc\n567\n7890"},
+			args: args{data: []byte("123345\nabcd\n456\n123\nabc\n567\n7890")},
 			want: "0987\n765\ncba\n321\n654\ndcba\n543321",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := Reverse{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("Reverse() = %v, want %v", got, tt.want)
 			}
 		})
@@ -390,7 +390,7 @@ func TestStringReverse_Transform(t *testing.T) {
 
 func TestCountWords_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -401,24 +401,24 @@ func TestCountWords_Transform(t *testing.T) {
 	}{
 		{
 			name: "count number of words in string",
-			args: args{input: "hello world"},
+			args: args{data: []byte("hello world")},
 			want: "2",
 		},
 		{
 			name: "count number of words in string contains spaces",
-			args: args{input: " This  is string having spaces?"},
+			args: args{data: []byte(" This  is string having spaces?")},
 			want: "5",
 		},
 		{
 			name: "count number of words in comma separated string",
-			args: args{input: "word1, word2, word3"},
+			args: args{data: []byte("word1, word2, word3")},
 			want: "3",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := CountWords{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("CountWords() = %v, want %v", got, tt.want)
 			}
 		})
@@ -427,7 +427,7 @@ func TestCountWords_Transform(t *testing.T) {
 
 func TestCountLines_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -438,29 +438,29 @@ func TestCountLines_Transform(t *testing.T) {
 	}{
 		{
 			name: "Count one line",
-			args: args{input: "one line"},
+			args: args{data: []byte("one line")},
 			want: "1",
 		},
 		{
 			name: "Count two line",
-			args: args{input: "1st line\n 2nd line"},
+			args: args{data: []byte("1st line\n 2nd line")},
 			want: "2",
 		},
 		{
 			name: "Count empty line",
-			args: args{input: "\n\n\n"},
+			args: args{data: []byte("\n\n\n")},
 			want: "3",
 		},
 		{
 			name: "Count empty + text line",
-			args: args{input: "\n\n2nd line\n"},
+			args: args{data: []byte("\n\n2nd line\n")},
 			want: "3",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := CountLines{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("CountLines() = %v, want %v", got, tt.want)
 			}
 		})
@@ -469,7 +469,7 @@ func TestCountLines_Transform(t *testing.T) {
 
 func TestStringToCamel(t *testing.T) {
 	type args struct {
-		data string
+		data []byte
 		in1  []Flag
 	}
 	tests := []struct {
@@ -480,11 +480,11 @@ func TestStringToCamel(t *testing.T) {
 	}{
 		{
 			name: "String",
-			args: args{data: "the quick brown fox jumps over a lazy dog"},
+			args: args{data: []byte("the quick brown fox jumps over a lazy dog")},
 			want: "TheQuickBrownFoxJumpsOverALazyDog",
 		}, {
 			name: "String Uppercase",
-			args: args{data: "THE QUICK BROWN FOX JUMPS OVER A LAZY DOG"},
+			args: args{data: []byte("THE QUICK BROWN FOX JUMPS OVER A LAZY DOG")},
 			want: "THEQUICKBROWNFOXJUMPSOVERALAZYDOG",
 		},
 	}
@@ -550,7 +550,7 @@ func TestExtractEmails_Command(t *testing.T) {
 
 func TestExtractEmails_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		opts  []Flag
 	}
 	tests := []struct {
@@ -561,34 +561,34 @@ func TestExtractEmails_Transform(t *testing.T) {
 	}{
 		{
 			name: "Email in single line string",
-			args: args{input: "this is example@gmail.com"},
+			args: args{data: []byte("this is example@gmail.com")},
 			want: "example@gmail.com",
 		},
 		{
 			name: "Multiple Emails in single line string",
-			args: args{input: "this is example@gmail.com and this is example2@gmail.com"},
+			args: args{data: []byte("this is example@gmail.com and this is example2@gmail.com")},
 			want: "example@gmail.com\nexample2@gmail.com",
 		},
 		{
 			name: "No email in text",
-			args: args{input: "there is no email in text"},
+			args: args{data: []byte("there is no email in text")},
 			want: "",
 		},
 		{
 			name: "Fake emails",
-			args: args{input: "this is @fake.com email"},
+			args: args{data: []byte("this is @fake.com email")},
 			want: "",
 		},
 		{
 			name: "Multiple Emails with separator flag",
-			args: args{input: "this is example@gmail.com and this is example2@gmail.com", opts: []Flag{{Short: "s", Value: ","}}},
+			args: args{data: []byte("this is example@gmail.com and this is example2@gmail.com"), opts: []Flag{{Short: "s", Value: ","}}},
 			want: "example@gmail.com,example2@gmail.com",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := ExtractEmails{}
-			if got, _ := p.Transform(tt.args.input, tt.args.opts...); got != tt.want {
+			if got, _ := p.Transform(tt.args.data, tt.args.opts...); got != tt.want {
 				t.Errorf("ExtractEmails() = %v, want %v", got, tt.want)
 			}
 		})

--- a/processors/url.go
+++ b/processors/url.go
@@ -15,8 +15,8 @@ func (p URLEncode) Alias() []string {
 	return []string{"url-enc"}
 }
 
-func (p URLEncode) Transform(input string, _ ...Flag) (string, error) {
-	return url.QueryEscape(input), nil
+func (p URLEncode) Transform(data []byte, _ ...Flag) (string, error) {
+	return url.QueryEscape(string(data)), nil
 }
 
 func (p URLEncode) Flags() []Flag {
@@ -46,8 +46,8 @@ func (p URLDecode) Alias() []string {
 	return []string{"url-dec"}
 }
 
-func (p URLDecode) Transform(input string, _ ...Flag) (string, error) {
-	res, _ := url.QueryUnescape(input)
+func (p URLDecode) Transform(data []byte, _ ...Flag) (string, error) {
+	res, _ := url.QueryUnescape(string(data))
 	return res, nil
 }
 

--- a/processors/url_test.go
+++ b/processors/url_test.go
@@ -44,7 +44,7 @@ func TestURLEncode_Command(t *testing.T) {
 
 func TestURLEncode_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -55,19 +55,19 @@ func TestURLEncode_Transform(t *testing.T) {
 	}{
 		{
 			name: "Special characters",
-			args: args{input: "http://example.com/test?test=something&value=*&^%$#@@#$%^&*("},
+			args: args{data: []byte("http://example.com/test?test=something&value=*&^%$#@@#$%^&*(")},
 			want: "http%3A%2F%2Fexample.com%2Ftest%3Ftest%3Dsomething%26value%3D%2A%26%5E%25%24%23%40%40%23%24%25%5E%26%2A%28",
 		},
 		{
 			name: "Special characters",
-			args: args{input: " ?&=#+%!<>#\\\"{}|\\\\^[]`☺\\t:/@$'()*,;"},
+			args: args{data: []byte(" ?&=#+%!<>#\\\"{}|\\\\^[]`☺\\t:/@$'()*,;")},
 			want: "+%3F%26%3D%23%2B%25%21%3C%3E%23%5C%22%7B%7D%7C%5C%5C%5E%5B%5D%60%E2%98%BA%5Ct%3A%2F%40%24%27%28%29%2A%2C%3B",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := URLEncode{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -118,7 +118,7 @@ func TestURLDecode_Command(t *testing.T) {
 
 func TestURLDecode_Transform(t *testing.T) {
 	type args struct {
-		input string
+		data []byte
 		in1   []Flag
 	}
 	tests := []struct {
@@ -129,19 +129,19 @@ func TestURLDecode_Transform(t *testing.T) {
 	}{
 		{
 			name: "Special characters",
-			args: args{input: "http%3A%2F%2Fexample.com%2Ftest%3Ftest%3Dsomething%26value%3D%2A%26%5E%25%24%23%40%40%23%24%25%5E%26%2A%28"},
+			args: args{data: []byte("http%3A%2F%2Fexample.com%2Ftest%3Ftest%3Dsomething%26value%3D%2A%26%5E%25%24%23%40%40%23%24%25%5E%26%2A%28")},
 			want: "http://example.com/test?test=something&value=*&^%$#@@#$%^&*(",
 		},
 		{
 			name: "Special characters",
-			args: args{input: "+%3F%26%3D%23%2B%25%21%3C%3E%23%5C%22%7B%7D%7C%5C%5C%5E%5B%5D%60%E2%98%BA%5Ct%3A%2F%40%24%27%28%29%2A%2C%3B"},
+			args: args{data: []byte("+%3F%26%3D%23%2B%25%21%3C%3E%23%5C%22%7B%7D%7C%5C%5C%5E%5B%5D%60%E2%98%BA%5Ct%3A%2F%40%24%27%28%29%2A%2C%3B")},
 			want: " ?&=#+%!<>#\\\"{}|\\\\^[]`☺\\t:/@$'()*,;",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := URLDecode{}
-			got, err := p.Transform(tt.args.input, tt.args.in1...)
+			got, err := p.Transform(tt.args.data, tt.args.in1...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Transform() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -82,7 +82,7 @@ func (u UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var err error
 			i, ok := u.list.SelectedItem().(processors.Processor)
 			if ok {
-				data, err = i.Transform(u.input)
+				data, err = i.Transform([]byte(u.input))
 				if err != nil {
 					data = fmt.Sprintf("error: %s", err.Error())
 				}

--- a/utils/text.go
+++ b/utils/text.go
@@ -32,12 +32,12 @@ func ReadMultilineInput() string {
 	return strings.Join(str[:len(str)-1], "\n")
 }
 
-func ToKebabCase(input string) string {
-	input = regexp.MustCompile(`\s+`).ReplaceAllString(input, " ")
-	return strcase.ToKebab(input)
+func ToKebabCase(input []byte) string {
+	str := regexp.MustCompile(`\s+`).ReplaceAllString(string(input), " ")
+	return strcase.ToKebab(str)
 }
 
-func ToLowerCamelCase(input string) string {
-	input = regexp.MustCompile(`\s+`).ReplaceAllString(input, " ")
-	return strcase.ToLowerCamel(input)
+func ToLowerCamelCase(input []byte) string {
+	str := regexp.MustCompile(`\s+`).ReplaceAllString(string(input), " ")
+	return strcase.ToLowerCamel(str)
 }


### PR DESCRIPTION
- Adds the ability to read files directly. If the first argument is a file, its content is used as the input (like in tools like `cat` etc.).
- Changed the parameter type for the transform function to `[]byte` to support building checksums of binary files.
- Unified the naming of the 1st parameter of the transform function, was a mix out of `input` and `data`.

I used the file-reading on the README.md, the sttr binary itself and the lazygit binary (`commit=50e2ba542264937ead2b9f914c0605acb1ef7924, build date=2021-06-01T16:08:11Z, build source=binaryRelease, version=v0.28.1-next, os=darwin, arch=amd64`) and compared it with the results of the tools `md5` and `shasum` (macOS):
![Screenshot 2021-10-01 at 21 22 13](https://user-images.githubusercontent.com/8960898/135677157-9600844f-29b3-4e24-a5da-f8dd331e160b.png)